### PR TITLE
Pull in changes from `json-e/json-e`

### DIFF
--- a/internal/jsone_test.go
+++ b/internal/jsone_test.go
@@ -3,7 +3,7 @@ package jsone
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -48,7 +48,7 @@ func TestSpec(t *testing.T) {
 	// in gopkg.in/yaml.v2
 
 	// Read specification.yml
-	data, err := ioutil.ReadFile("../specification.yml")
+	data, err := os.ReadFile("../specification.yml")
 	require.NoError(t, err, "failed to read specification.yml")
 	// Parse as YAML (split for each document)
 	var rawSpec []interface{}

--- a/js/package.json
+++ b/js/package.json
@@ -31,7 +31,7 @@
     "browserify": "^14.5.0",
     "eslint": "^5.12.1",
     "mocha": "^9.2.0",
-    "rollup": "^2.66.0",
+    "rollup": "^3.29.5",
     "source-map-support": "^0.5.0",
     "timekeeper": "^2.0.0"
   },

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1956,10 +1956,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
-rollup@^2.66.0:
-  version "2.66.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.66.0.tgz#ee529ea15a20485d579039637fec3050bad03bbb"
-  integrity sha512-L6mKOkdyP8HK5kKJXaiWG7KZDumPJjuo1P+cfyHOJPNNTK3Moe7zCH5+fy7v8pVmHXtlxorzaBjvkBMB23s98g==
+rollup@^3.29.5:
+  version "3.29.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.5.tgz#8a2e477a758b520fb78daf04bca4c522c1da8a54"
+  integrity sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
Update fork to get golang failure fixes
